### PR TITLE
Added TypeScriptCompile to CollectedFiles.

### DIFF
--- a/Source/OctoPack.Precompile.targets
+++ b/Source/OctoPack.Precompile.targets
@@ -35,6 +35,7 @@
       <CollectedFiles Include="@(FileWrites)" Exclude="$(IntermediateOutputPath)**\*" />
       <CollectedFiles Include="@(FileWritesShareable)" Exclude="$(IntermediateOutputPath)**\*" />
       <CollectedFiles Include="@(Content)" />
+      <CollectedFiles Include="@(TypeScriptCompile)" />
 
       <!--
         Some of the collected file paths are full paths, but we need paths relative to the project so we can perform a recursive copy.


### PR DESCRIPTION
Your comment states that CollectedFiles should collect the files the same way as OctoPack but you did not include `@(TypeScriptCompile)` (https://github.com/OctopusDeploy/OctoPack/blob/abd0c5d30cfd0572ff066b83436969661b9cdbd4/source/tools/OctoPack.targets#L73) and this patch adds that. You might want to change your comment if you did not include this on purpose.
