### PR TITLE
Allow skipping precompilation via /p:RunOctoPackPrecompile=false

### DIFF
--- a/Source/OctoPack.Precompile.targets
+++ b/Source/OctoPack.Precompile.targets
@@ -7,7 +7,7 @@
     <OctoPackPrecompileNuSpecFileName Condition="'$(OctoPackPrecompileNuSpecFileName)'==''">$(IntermediateOutputPath)$(OctoPackProjectName).nuspec</OctoPackPrecompileNuSpecFileName>
   </PropertyGroup>
 
-  <Target Name="GenerateOctoPackPrecompileNuSpecFile" BeforeTargets="OctoPackPrecompile" Condition="'$(OctoPackNuSpecFileName)' == '' AND !Exists('$(OctoPackProjectName).nuspec')">
+  <Target Name="GenerateOctoPackPrecompileNuSpecFile" BeforeTargets="OctoPackPrecompile" Condition="$(RunOctoPackPrecompile) AND '$(OctoPackNuSpecFileName)' == '' AND !Exists('$(OctoPackProjectName).nuspec')">
     <PropertyGroup>
       <OctoPackNuSpecFileName>$(OctoPackPrecompileNuSpecFileName)</OctoPackNuSpecFileName>
       <PrecompileNuSpecFileContent>

--- a/Source/OctoPack.Precompile.targets
+++ b/Source/OctoPack.Precompile.targets
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <RunOctoPackPrecompile Condition="'$(RunOctoPackPrecompile)'==''">true</RunOctoPackPrecompile>
     <OctoPackPrecompileIntermediateOutputPath Condition="'$(OctoPackPrecompileIntermediateOutputPath)'==''">$(IntermediateOutputPath)PrecompiledIntermediate\</OctoPackPrecompileIntermediateOutputPath>
     <OctoPackPrecompileOutputPath Condition="'$(OctoPackPrecompileOutputPath)'==''">$(IntermediateOutputPath)Precompiled\</OctoPackPrecompileOutputPath>
     <OctoPackPrecompileNuSpecFileName Condition="'$(OctoPackPrecompileNuSpecFileName)'==''">$(IntermediateOutputPath)$(OctoPackProjectName).nuspec</OctoPackPrecompileNuSpecFileName>
@@ -29,7 +30,7 @@
     <WriteLinesToFile File="$(OctoPackNuSpecFileName)" Lines="$(PrecompileNuSpecFileContent)" Overwrite="true" />
   </Target>
 
-  <Target Name="OctoPackPrecompile" BeforeTargets="OctoPack" Condition="$(RunOctoPack)">
+  <Target Name="OctoPackPrecompile" BeforeTargets="OctoPack" Condition="$(RunOctoPack) AND $(RunOctoPackPrecompile)">
     <ItemGroup>
       <!-- This should collect the files the same way OctoPack does. https://github.com/OctopusDeploy/OctoPack -->
       <CollectedFiles Include="@(FileWrites)" Exclude="$(IntermediateOutputPath)**\*" />


### PR DESCRIPTION
Adds a new property named RunOctoPackPrecompile that defaults to true.  Allows conditional skipping of precompile step.

Primary use-case is for cases where you are building/packaging non-production packages and would prefer a lower build time over a lower initial runtime.