### PR TITLE
Do not copy file that have metadata property "Exclude" with the value "True"

### DIFF
--- a/OctoPack.Precompile/OctoPack.Precompile.targets
+++ b/OctoPack.Precompile/OctoPack.Precompile.targets
@@ -44,7 +44,7 @@
       -->
       <CollectedFiles Remove="packages.config" />
       
-      <NormalizedFiles Include="@(CollectedFiles)" Condition="'%(CollectedFiles.Link)' == ''">
+      <NormalizedFiles Include="@(CollectedFiles)" Condition="'%(CollectedFiles.Link)' == '' AND '%(CollectedFiles.Exclude)' != 'True' ">
         <!--
           The Identity metadata of the items are inconsistent, some of them are full paths and some of them are relative. To keep the file and directory
           structure during the copy we need the relative path, so we take the FullPath metadata and calculate the relative path manually.


### PR DESCRIPTION
See https://github.com/LorandBiro/OctoPack.Precompile/issues/10

This change excludes files that have a metatdata property of "Exclude" set to "True"